### PR TITLE
:recycle:  Refactor state management for manual page reload

### DIFF
--- a/src/app/services/board/board.service.spec.ts
+++ b/src/app/services/board/board.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BoardService } from './board.service';
+
+describe('BoardService', () => {
+  let service: BoardService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BoardService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/board/board.service.ts
+++ b/src/app/services/board/board.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Board } from '../login/board';
+import { Observable, BehaviorSubject } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+const headers = new HttpHeaders({'Content-Type':  'application/json'})
+
+const httpOptions = {
+  headers: headers,
+  withCredentials: true
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BoardService {
+  boardId: string | undefined = undefined;
+  board: BehaviorSubject<Board | null> = new BehaviorSubject<Board | null>(null);
+
+  constructor(private http: HttpClient) {}
+
+  getBoard(boardId: string) {
+    if (boardId !== this.boardId && this.board.value === null) {
+      this.boardId = boardId
+      const boardUrl = `board/${boardId}`
+
+      this.http.get<Board>(environment.baseUrl + boardUrl, httpOptions)
+        .subscribe({
+          next: board => this.board.next(board),
+          error: () => this.board.next(null),
+          complete: () => this.board.complete()
+        })
+    }
+  }
+}

--- a/src/app/services/login/login.service.ts
+++ b/src/app/services/login/login.service.ts
@@ -4,6 +4,8 @@ import { Observable } from 'rxjs'
 import { HttpClient, HttpHeaders } from '@angular/common/http'
 import { environment } from 'src/environments/environment'
 import { Board } from './board'
+import { BoardService } from '../board/board.service'
+import { tap } from 'rxjs/operators'
 
 const headers = new HttpHeaders({'Content-Type':  'application/json'})
 
@@ -19,7 +21,8 @@ export class LoginService {
   private loginUrl = 'login/'
   public board: Board | null = null
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient,
+              private boardService: BoardService) { }
 
   login(username: string, password: string, id: string): Observable<Board> {
     const login: Login = {
@@ -27,19 +30,21 @@ export class LoginService {
       username,
       password
     }
+    this.boardService.boardId = id
 
     return this.http.post<Board>(environment.baseUrl + this.loginUrl, login, httpOptions)
+      .pipe(tap(val => this.boardService.board.next(val)))
   }
 
   logout(): Observable<void> {
-    sessionStorage.removeItem('isAuthenticated')
+    localStorage.removeItem('isAuthenticated')
     this.board = null
 
     return this.http.get<void>(environment.baseUrl + 'logout', httpOptions)
   }
 
   getAuthenticated(): boolean {
-    const isAuthenticated = sessionStorage.getItem('isAuthenticated')
+    const isAuthenticated = localStorage.getItem('isAuthenticated')
     if (isAuthenticated !== null) {
       return Boolean(JSON.parse(isAuthenticated))
     }
@@ -48,6 +53,6 @@ export class LoginService {
   }
 
   setAuthenticated(isAuthenticated: boolean): void {
-    sessionStorage.setItem('isAuthenticated', `${isAuthenticated}`)
+    localStorage.setItem('isAuthenticated', `${isAuthenticated}`)
   }
 }


### PR DESCRIPTION
- use localStorage instead of sessionStorage to better deal with manual page reload
- fetch board type on Configuration page so as to not be stuck on the page or have to go back to login in case the page was manually reloaded